### PR TITLE
PEP8/Standards Cleanup

### DIFF
--- a/honkbot.py
+++ b/honkbot.py
@@ -221,7 +221,7 @@ class Honkbot:
         search = message.content.lower().split(" ")
         del search[0]
         if search:
-            auth = {"Authorization": "Token {}".format(speedrun_api)}
+            auth = {"Authorization": "Token {}".format(self.speedrun_api)}
             query = " ".join(search)
             results = []
             if len(search) < 100:
@@ -250,11 +250,12 @@ class Honkbot:
                             if category['name'].startswith('Any%'):
                                 game_category = category
                                 break
+                        game_records_url = ""
                         if game_category:
                             for link in game_category['links']:
                                 if "records" in link['rel']:
-                                    game_records = link['uri']
-                            r = requests.get(game_records, headers=auth)
+                                    game_records_url = link['uri']
+                            r = requests.get(game_records_url, headers=auth)
                             run = r.json()['data'][0]['runs'][0]['run']
                             record = run['times']['realtime'][2:]
                             user_id = run['players'][0]['id']
@@ -317,7 +318,7 @@ class Honkbot:
                 url = (
                     "https://www.googleapis.com/customsearch/v1?q={}".format(search) +
                     "&cx=009855409252983983547:3xrcodch8sc&searchType=image" +
-                    "&key={}".format(google_api))
+                    "&key={}".format(self.google_api))
                 r = requests.get(url)
                 try:
                     response = r.json()["items"][0]["link"]
@@ -350,10 +351,10 @@ class Honkbot:
             query = " ".join(search)
             if len(query) < 250:
                 url = "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&q={0}&key={1}"\
-                    .format(query, google_api)
+                    .format(query, self.google_api)
                 r = requests.get(url)
                 try:
-                    response = r.json()['items'][0]["id"]["videoId"]
+                    response = r.json()["items"][0]["id"]["videoId"]
                 except IndexError:
                     await self.client.send_message(message.channel, "Could not find any videos with search {0}"
                                                    .format(query))
@@ -403,9 +404,9 @@ class Honkbot:
 if "__main__" in __name__:
 
     dotenv.load_dotenv()
-    discord_api = os.getenv("DISCORD_API_KEY")
-    speedrun_api = os.getenv("SPEEDRUN_API_KEY")
-    google_api = os.getenv("GOOGLE_API_KEY")
+    discord_api_key = os.getenv("DISCORD_API_KEY")
+    speedrun_api_key = os.getenv("SPEEDRUN_API_KEY")
+    google_api_key = os.getenv("GOOGLE_API_KEY")
 
-    bot = Honkbot(discord_api, speedrun_api, google_api)
+    bot = Honkbot(discord_api_key, speedrun_api_key, google_api_key)
     bot.run()

--- a/honkbot.py
+++ b/honkbot.py
@@ -150,9 +150,10 @@ class Honkbot:
         Required:
         """
 
-        today = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+        today_in_japan = datetime.datetime.utcnow().replace(tzinfo=pytz.timezone("Japan"))
         # The "third" week is the 15th through the 21st
-        if today.weekday() == 1 and 15 <= today.day <= 21:
+        # If right now in Japan it's the third Tuesday
+        if today_in_japan.weekday() == 1 and 15 <= today_in_japan.day <= 21:
             ddr_message = self.get_display_time("us")
             other_message = self.get_display_time("extended")
         else:

--- a/honkbot.py
+++ b/honkbot.py
@@ -102,7 +102,7 @@ class Honkbot:
         elif message.content.startswith('!eamuse'):
             await self.get_eamuse_maintenance(message)
 
-        elif "honk" in message.content.lower() and "bot4u" not in message.author.name:
+        elif "honk" in message.content.lower() and message.author != self.client.user:
             # HONK WINS AGAIN
             if "Skeeter" in message.author.name:
                 await self.client.send_message(message.channel, "beep")

--- a/honkbot.py
+++ b/honkbot.py
@@ -1,4 +1,3 @@
-from calendar import monthrange
 import datetime
 import discord
 import logging
@@ -172,7 +171,7 @@ class Honkbot:
         """
         r = requests.get("http://quandyfactory.com/insult/json")
         insult = r.json()["insult"]
-        await self.client.send_message(message.channel, insult.replace("Thou art", "{0} is".format(name)))
+        await self.client.send_message(message.channel, insult.replace("Thou art", f"{name} is"))
 
     async def get_record(self, message):
         """
@@ -235,8 +234,8 @@ class Honkbot:
 
                             await self.client.send_message(
                                 message.channel,
-                                "The Any% record for {0} is {1} by {2}".format(game_name, record, user_name))
-                
+                                f"The Any% record for {game_name} is {record} by {user_name}")
+
                         else:
                             await self.client.send_message(
                                 message.channel,
@@ -286,16 +285,18 @@ class Honkbot:
         if search:
             query = " ".join(search)
             if len(query) < 150:
+                cx_id = "009855409252983983547:3xrcodch8sc"
                 url = (
-                    "https://www.googleapis.com/customsearch/v1?q={}".format(search) +
-                    "&cx=009855409252983983547:3xrcodch8sc&searchType=image" +
-                    "&key={}".format(self.google_api))
+                        f"https://www.googleapis.com/customsearch/v1?q={search}" +
+                        f"&cx={cx_id}&searchType=image" + f"&key={self.google_api}"
+                )
                 r = requests.get(url)
                 try:
                     response = r.json()["items"][0]["link"]
                     await self.client.send_message(message.channel, response)
                 except KeyError:
-                    await self.client.send_message(message.channel, "No results found for {0} :(".format(query))
+                    await self.client.send_message(message.channel,
+                                                   f"No results found for {query} :(")
             else:
                 await self.client.send_message(message.channel, "Query too big!")
         else:
@@ -321,21 +322,23 @@ class Honkbot:
         if search:
             query = " ".join(search)
             if len(query) < 250:
-                url = "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&q={0}&key={1}"\
-                    .format(query, self.google_api)
-                r = requests.get(url)
+                google_url = "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video"
+                search_query = f"&q={query}&key={self.google_api}"
+                r = requests.get(f"{google_url}{search_query}")
                 try:
                     response = r.json()["items"][0]["id"]["videoId"]
                 except IndexError:
-                    await self.client.send_message(message.channel, "Could not find any videos with search {0}"
-                                                   .format(query))
+                    await self.client.send_message(
+                        message.channel,
+                        f"Could not find any videos with search {query}"
+                    )
                     return
 
                 if response:
-                    await self.client.send_message(message.channel, "https://youtu.be/{0}".format(response))
+                    await self.client.send_message(message.channel, f"https://youtu.be/{response}")
                 else:
-                    await self.client.send_message(message.channel, "Could not find any videos with search {0}"
-                                                   .format(query))
+                    await self.client.send_message(message.channel,
+                                                   f"Could not find any videos with search {query}")
                     return
             else:
                 await self.client.send_message(message.channel, "Query too long!")
@@ -353,18 +356,20 @@ class Honkbot:
 
         allowed_roles = ['OH', 'MI', 'KY', 'PA', 'IN', 'NY']
         if len(message.content.split(" ")) != 2:
-            await self.client.send_message(message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles), "]"]))
+            await self.client.send_message(
+                message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles), "]"]))
             return
         role = message.content.split(" ")[1]
         if role not in allowed_roles:
-            await self.client.send_message(message.channel, "".join(["Allowed roles are: ", ", ".join(allowed_roles)]))
+            await self.client.send_message(
+                message.channel, "".join(["Allowed roles are: ", ", ".join(allowed_roles)]))
         else:
             role_object = discord.utils.get(message.server.roles, name=role)
             try:
                 if message.author.roles:
                     await self.client.replace_roles(message.author, role_object)
                 else:
-                    await self.client.add_roles(message.author, role_object) 
+                    await self.client.add_roles(message.author, role_object)
                 await self.client.send_message(
                     message.channel, "Adding {0} to {1}".format(message.author.name, role))
             except Forbidden:
@@ -373,7 +378,6 @@ class Honkbot:
 
 
 if "__main__" in __name__:
-
     dotenv.load_dotenv()
     discord_api_key = os.getenv("DISCORD_API_KEY")
     speedrun_api_key = os.getenv("SPEEDRUN_API_KEY")

--- a/honkbot.py
+++ b/honkbot.py
@@ -1,25 +1,22 @@
-import asyncio
 from calendar import monthrange
 import datetime
 import discord
 import logging
 import os
 import pytz
-import random
 import requests
 import sys
-import time
 
-from discord.ext import commands
 from discord.errors import Forbidden
 import dotenv
 
 logging.basicConfig(stream=sys.stdout, level=logging.WARN)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.warn("Starting Honkbot...")
+logger.warning("Starting Honkbot...")
 
-class Honkbot():
+
+class Honkbot:
     """
     HONK
 
@@ -49,7 +46,7 @@ class Honkbot():
             "!insult"
         ]
 
-        self.eamuse_maint = {
+        self.eamuse_maintenance = {
             "normal": ("20:00", "22:00"),
             "extended": ("17:00", "22:00"),
             "us": ("12:00", "17:00")
@@ -69,23 +66,23 @@ class Honkbot():
     def run(self):
         self.client.run(self.discord_api)
 
-    #@self.client.event
+    # @self.client.event
     async def on_ready(self):
-        logger.warn('Logged in as {0} - {1}'.format(self.client.user.name, self.client.user.id))
+        logger.warning('Logged in as {0} - {1}'.format(self.client.user.name, self.client.user.id))
 
-    #@self.client.event
-    #@asyncio.coroutine
+    # @self.client.event
+    # @asyncio.coroutine
     async def on_message(self, message):
         if message.content.startswith('!test'):
             test = "test"
-            await self.client.send_message(message.author, test)
+            self.client.send_message(message.author, test)
 
         elif message.content.startswith('!join'):
-            self.set_channel_role(message)
+            await self.set_channel_role(message)
 
         elif message.content.startswith('!help'):
-            commands = "".join(["Commands are: ",", ".join(self.command_list)])
-            await self.client.send_message(message.channel, commands)
+            commands = "".join(["Commands are: ", ", ".join(self.command_list)])
+            self.client.send_message(message.channel, commands)
 
         elif message.content.startswith('!youtube'):
             await self.search_youtube(message)
@@ -95,7 +92,7 @@ class Honkbot():
             if len(message.content.lower().split(" ")) > 1:
                 name = message.content.lower().split(" ")[1]
             else:
-                await self.client.send_message(message.channel, "No one to insult :(")
+                self.client.send_message(message.channel, "No one to insult :(")
                 return
             await self.get_insult(message, name=name)
         elif message.content.startswith('!ranatalus'):
@@ -103,20 +100,20 @@ class Honkbot():
         elif message.content.startswith('!record'):
             await self.get_record(message)
         elif message.content.startswith('!eamuse'):
-            await self.get_eamuse_maintenance()
+            await self.get_eamuse_maintenance(message)
 
         elif "honk" in message.content.lower() and "bot4u" not in message.author.name:
             # HONK WINS AGAIN
             if "Skeeter" in message.author.name:
-                await self.client.send_message(message.channel, "beep")
+                self.client.send_message(message.channel, "beep")
             else:
-                await self.client.send_message(message.channel, "HONK!")
+                self.client.send_message(message.channel, "HONK!")
 
         elif message.content.startswith('!'):
-            commands = "".join(["Commands are: ",", ".join(self.command_list)])
-            await self.client.send_message(message.channel, commands)
+            commands = "".join(["Commands are: ", ", ".join(self.command_list)])
+            self.client.send_message(message.channel, commands)
 
-    async def get_eamuse_maintenance(self):
+    async def get_eamuse_maintenance(self, message):
         """
         Gets eAmusement maintenance time.
 
@@ -131,65 +128,65 @@ class Honkbot():
         today = today.replace(tzinfo=pytz.utc)
         east_time = today.astimezone(pytz.timezone("America/New_York"))
         bom, days = monthrange(today.year, today.month)
-        firstmonday = (0 - bom) % 7 + 1
-        thirdmonday = range(firstmonday, days+1, 7)[2]
-        if today.day == thirdmonday:
-            maint['ddr'] = eamuse_maint['us']
-            maint['other'] = eamuse_maint['extended']
+        first_monday = (0 - bom) % 7 + 1
+        third_monday = range(first_monday, days+1, 7)[2]
+        if today.day == third_monday:
+            maint['ddr'] = self.eamuse_maintenance['us']
+            maint['other'] = self.eamuse_maintenance['extended']
         else:
             maint['ddr'] = None
-            maint['other'] = eamuse_maint['normal']
+            maint['other'] = self.eamuse_maintenance['normal']
 
         if maint['ddr']:
-            begin_time = east_time.replace(hour=int(maint['ddr'][0].split(":")[0]),minute=0)
-            end_time = east_time.replace(hour=int(maint['ddr'][1].split(":")[0]),minute=0)
-            if east_time >= begin_time and east_time <= end_time:
-                await self.client.send_message(
+            begin_time = east_time.replace(hour=int(maint['ddr'][0].split(":")[0]), minute=0)
+            end_time = east_time.replace(hour=int(maint['ddr'][1].split(":")[0]), minute=0)
+            if begin_time <= east_time <= end_time:
+                self.client.send_message(
                     message.channel,
-                    "DDR: :x: - {0}-{1}".format(maint['ddr'][0],maint['ddr'][1]))
+                    "DDR: :x: - {0}-{1}".format(maint['ddr'][0], maint['ddr'][1]))
             else:
-                await self.client.send_message(
+                self.client.send_message(
                     message.channel,
-                    "DDR: :white_check_mark: - {0}-{1}".format(maint['ddr'][0],maint['ddr'][1]))
+                    "DDR: :white_check_mark: - {0}-{1}".format(maint['ddr'][0], maint['ddr'][1]))
 
-            begin_time = today.replace(hour=int(maint['other'][0].split(":")[0]),minute=0)
-            end_time = today.replace(hour=int(maint['other'][1].split(":")[0]),minute=0)
+            begin_time = today.replace(hour=int(maint['other'][0].split(":")[0]), minute=0)
+            end_time = today.replace(hour=int(maint['other'][1].split(":")[0]), minute=0)
             if (
-                east_time >= begin_time.astimezone(pytz.timezone("America/New_York")) and
-                east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
+                    begin_time.astimezone(pytz.timezone("America/New_York"))
+                    <= east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
             ):
-                await self.client.send_message(
+                self.client.send_message(
                     message.channel,
                     "Other: :x: - {0}-{1}".format(
                         begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                         end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
             else:
-                await self.client.send_message(
+                self.client.send_message(
                     message.channel,
                     "Other: :white_check_mark: - {0}-{1}".format(
                         begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                         end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
         else:
-            await self.client.send_message(
+            self.client.send_message(
                 message.channel, "DDR: :white_check_mark: - no maintenance today")
-            begin_time = today.replace(hour=int(maint['other'][0].split(":")[0]),minute=0)
-            end_time = today.replace(hour=int(maint['other'][1].split(":")[0]),minute=0)
-            if east_time.weekday() in [4,5]:
-                await self.client.send_message(
+            begin_time = today.replace(hour=int(maint['other'][0].split(":")[0]), minute=0)
+            end_time = today.replace(hour=int(maint['other'][1].split(":")[0]), minute=0)
+            if east_time.weekday() in [4, 5]:
+                self.client.send_message(
                     message.channel, "Other: :white_check_mark: - no maintenance today")
             else:
                 if (
-                    east_time >= begin_time.astimezone(pytz.timezone("America/New_York")) and
-                    east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
+                        begin_time.astimezone(pytz.timezone("America/New_York"))
+                        <= east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
                 ):
 
-                    await self.client.send_message(
+                    self.client.send_message(
                         message.channel,
                         "Other: :x: - {0}-{1}".format(
                             begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                             end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
                 else:
-                    await self.client.send_message(
+                    self.client.send_message(
                         message.channel,
                         "Other: :white_check_mark: - {0}-{1}".format(
                             begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
@@ -204,8 +201,7 @@ class Honkbot():
         """
         r = requests.get("http://quandyfactory.com/insult/json")
         insult = r.json()["insult"]
-        await self.client.send_message(message.channel, insult.replace("Thou art","{0} is".format(name)))
-
+        self.client.send_message(message.channel, insult.replace("Thou art", "{0} is".format(name)))
 
     async def get_record(self, message):
         """
@@ -216,7 +212,7 @@ class Honkbot():
         """
 
         if not self.speedrun_api:
-            await self.client.send_message(
+            self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -225,76 +221,76 @@ class Honkbot():
         search = message.content.lower().split(" ")
         del search[0]
         if search:
-            auth = {"Authorization":"Token {}".format(speedrun_api)}
+            auth = {"Authorization": "Token {}".format(speedrun_api)}
             query = " ".join(search)
             results = []
             if len(search) < 100:
-                baseUrl = "http://www.speedrun.com/api/v1/"
-                apiNext = "".join([baseUrl, "games?name={}".format(query)])
-                while apiNext:
-                    r = requests.get(apiNext,headers=auth)
+                base_url = "http://www.speedrun.com/api/v1/"
+                api_next = "".join([base_url, "games?name={}".format(query)])
+                while api_next:
+                    r = requests.get(api_next, headers=auth)
                     for game in r.json()["data"]:
                         results.append(game)
-                    nextPage = ""
+                    next_page = ""
                     for page in r.json()["pagination"]["links"]:
                         if "next" in page['rel']:
-                            nextPage = page['uri']
-                    apiNext = nextPage
+                            next_page = page['uri']
+                    api_next = next_page
                 if results:
                     if query == self.lastRecordSearch:
                         results = [results[0]]
                     if len(results) == 1:
-                        gameId = results[0]["id"]
-                        r = requests.get("".join([baseUrl,"games/",gameId]),headers=auth)
-                        gameName = r.json()['data']['names']['international']
+                        game_id = results[0]["id"]
+                        r = requests.get("".join([base_url, "games/", game_id]), headers=auth)
+                        game_name = r.json()['data']['names']['international']
                         r = requests.get(
-                            "".join([baseUrl,"games/",gameId,"/categories"]),headers=auth)
-                        gameCategory = ""
+                            "".join([base_url, "games/", game_id, "/categories"]), headers=auth)
+                        game_category = ""
                         for category in r.json()['data']:
                             if category['name'].startswith('Any%'):
-                                gameCategory = category
+                                game_category = category
                                 break
-                        if gameCategory:
-                            for link in gameCategory['links']:
+                        if game_category:
+                            for link in game_category['links']:
                                 if "records" in link['rel']:
-                                    gameRecords = link['uri']
-                            r = requests.get(gameRecords, headers=auth)
+                                    game_records = link['uri']
+                            r = requests.get(game_records, headers=auth)
                             run = r.json()['data'][0]['runs'][0]['run']
                             record = run['times']['realtime'][2:]
-                            userId = run['players'][0]['id']
-                            r = requests.get("".join([baseUrl,"users/",userId]),headers=auth)
-                            userName = r.json()['data']['names']['international']
+                            user_id = run['players'][0]['id']
+                            r = requests.get("".join([base_url, "users/", user_id]), headers=auth)
+                            user_name = r.json()['data']['names']['international']
 
-                            await self.client.send_message(
+                            self.client.send_message(
                                 message.channel,
-                                "The Any% record for {0} is {1} by {2}".format(gameName,record,userName))
+                                "The Any% record for {0} is {1} by {2}".format(game_name, record, user_name))
                 
                         else:
-                            await self.client.send_message(
+                            self.client.send_message(
                                 message.channel,
-                                "There are no Any% records for {}".format(gameName))
+                                "There are no Any% records for {}".format(game_name))
                     elif len(results) < 5:
                         names = []
                         for result in results:
                             names.append(result['names']['international'])
-                        await self.client.send_message(
+                        self.client.send_message(
                             message.channel,
                             "Multiple results. Do a search for the following: {}".format(
                                 ", ".join(names)))
-                        await self.client.send_message(
+                        self.client.send_message(
                             message.channel,
                             "If you want the first result, redo the search")
                     else:
-                        await self.client.send_message(
+                        self.client.send_message(
                             message.channel,
                             "Too many results! Be a little more specific")
                 else:
-                    await self.client.send_message(
+                    self.client.send_message(
                         message.channel,
                         "No games with that name found!")
             self.lastRecordSearch = query
         else:
-            await self.client.send_message(
+            self.client.send_message(
                 message.channel,
                 "You gotta give me a game to look for...")
 
@@ -307,7 +303,7 @@ class Honkbot():
         """
 
         if not self.google_api:
-            await self.client.send_message(
+            self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -325,13 +321,13 @@ class Honkbot():
                 r = requests.get(url)
                 try:
                     response = r.json()["items"][0]["link"]
-                    await self.client.send_message(message.channel, response)
+                    self.client.send_message(message.channel, response)
                 except KeyError:
-                    await self.client.send_message(message.channel, "No results found for {0} :(".format(query))
+                    self.client.send_message(message.channel, "No results found for {0} :(".format(query))
             else:
-                await self.client.send_message(message.channel, "Query too big!")
+                self.client.send_message(message.channel, "Query too big!")
         else:
-            await self.client.send_message(message.channel, "Usage: !image <search term>")
+            self.client.send_message(message.channel, "Usage: !image <search term>")
 
     async def search_youtube(self, message):
         """
@@ -342,7 +338,7 @@ class Honkbot():
         """
 
         if not self.google_api:
-            await self.client.send_message(
+            self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -353,25 +349,25 @@ class Honkbot():
         if search:
             query = " ".join(search)
             if len(query) < 250:
-                url = "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&q={0}&key={1}".format(query, google_api)
+                url = "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&q={0}&key={1}"\
+                    .format(query, google_api)
                 r = requests.get(url)
                 try:
                     response = r.json()['items'][0]["id"]["videoId"]
                 except IndexError:
-                    await self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
+                    self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
                     return
 
                 if response:
-                    await self.client.send_message(message.channel, "https://youtu.be/{0}".format(response))
+                    self.client.send_message(message.channel, "https://youtu.be/{0}".format(response))
                 else:
-                    await self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
+                    self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
                     return
             else:
-                await self.client.send_message(message.channel, "Query too long!")
+                self.client.send_message(message.channel, "Query too long!")
                 return
         else:
-            await self.client.send_message(message.channel, "Usage: !youtube <search terms>")
-
+            self.client.send_message(message.channel, "Usage: !youtube <search terms>")
 
     async def set_channel_role(self, message):
         """
@@ -381,27 +377,24 @@ class Honkbot():
             message (obj) - message object from discord object
         """
 
-        allowed_roles = ['OH','MI','KY','PA', 'IN', 'NY']
+        allowed_roles = ['OH', 'MI', 'KY', 'PA', 'IN', 'NY']
         if len(message.content.split(" ")) != 2:
-            await self.client.send_message(message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles),"]"]))
+            self.client.send_message(message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles), "]"]))
             return
         role = message.content.split(" ")[1]
         if role not in allowed_roles:
-            await self.client.send_message(message.channel, "".join(["Allowed roles are: ",", ".join(allowed_roles)]))
+            self.client.send_message(message.channel, "".join(["Allowed roles are: ", ", ".join(allowed_roles)]))
         else:
-            server_roles = message.server.roles
-            for server_role in server_roles:
-                if server_role.name == role:
-                    role_object = server_role
+            role_object = discord.utils.get(message.server.roles, name=role)
             try:
                 if message.author.roles:
                     await self.client.replace_roles(message.author, role_object)
                 else:
                     await self.client.add_roles(message.author, role_object) 
-                await self.client.send_message(
+                self.client.send_message(
                     message.channel, "Adding {0} to {1}".format(message.author.name, role))
             except Forbidden:
-                await self.client.send_message(
+                self.client.send_message(
                     message.channel, "I do not have permissions to assign roles right now. Sorry!")
 
 

--- a/honkbot.py
+++ b/honkbot.py
@@ -13,7 +13,7 @@ import dotenv
 logging.basicConfig(stream=sys.stdout, level=logging.WARN)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.warning("Starting Honkbot...")
+logger.info("Starting Honkbot...")
 
 
 class Honkbot:
@@ -68,21 +68,21 @@ class Honkbot:
 
     # @self.client.event
     async def on_ready(self):
-        logger.warning('Logged in as {0} - {1}'.format(self.client.user.name, self.client.user.id))
+        logger.info('Logged in as {0} - {1}'.format(self.client.user.name, self.client.user.id))
 
     # @self.client.event
     # @asyncio.coroutine
     async def on_message(self, message):
         if message.content.startswith('!test'):
             test = "test"
-            self.client.send_message(message.author, test)
+            await self.client.send_message(message.author, test)
 
         elif message.content.startswith('!join'):
             await self.set_channel_role(message)
 
         elif message.content.startswith('!help'):
             commands = "".join(["Commands are: ", ", ".join(self.command_list)])
-            self.client.send_message(message.channel, commands)
+            await self.client.send_message(message.channel, commands)
 
         elif message.content.startswith('!youtube'):
             await self.search_youtube(message)
@@ -92,7 +92,7 @@ class Honkbot:
             if len(message.content.lower().split(" ")) > 1:
                 name = message.content.lower().split(" ")[1]
             else:
-                self.client.send_message(message.channel, "No one to insult :(")
+                await self.client.send_message(message.channel, "No one to insult :(")
                 return
             await self.get_insult(message, name=name)
         elif message.content.startswith('!ranatalus'):
@@ -105,13 +105,13 @@ class Honkbot:
         elif "honk" in message.content.lower() and "bot4u" not in message.author.name:
             # HONK WINS AGAIN
             if "Skeeter" in message.author.name:
-                self.client.send_message(message.channel, "beep")
+                await self.client.send_message(message.channel, "beep")
             else:
-                self.client.send_message(message.channel, "HONK!")
+                await self.client.send_message(message.channel, "HONK!")
 
         elif message.content.startswith('!'):
             commands = "".join(["Commands are: ", ", ".join(self.command_list)])
-            self.client.send_message(message.channel, commands)
+            await self.client.send_message(message.channel, commands)
 
     async def get_eamuse_maintenance(self, message):
         """
@@ -141,11 +141,11 @@ class Honkbot:
             begin_time = east_time.replace(hour=int(maint['ddr'][0].split(":")[0]), minute=0)
             end_time = east_time.replace(hour=int(maint['ddr'][1].split(":")[0]), minute=0)
             if begin_time <= east_time <= end_time:
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel,
                     "DDR: :x: - {0}-{1}".format(maint['ddr'][0], maint['ddr'][1]))
             else:
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel,
                     "DDR: :white_check_mark: - {0}-{1}".format(maint['ddr'][0], maint['ddr'][1]))
 
@@ -155,24 +155,24 @@ class Honkbot:
                     begin_time.astimezone(pytz.timezone("America/New_York"))
                     <= east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
             ):
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel,
                     "Other: :x: - {0}-{1}".format(
                         begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                         end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
             else:
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel,
                     "Other: :white_check_mark: - {0}-{1}".format(
                         begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                         end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
         else:
-            self.client.send_message(
+            await self.client.send_message(
                 message.channel, "DDR: :white_check_mark: - no maintenance today")
             begin_time = today.replace(hour=int(maint['other'][0].split(":")[0]), minute=0)
             end_time = today.replace(hour=int(maint['other'][1].split(":")[0]), minute=0)
             if east_time.weekday() in [4, 5]:
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel, "Other: :white_check_mark: - no maintenance today")
             else:
                 if (
@@ -180,13 +180,13 @@ class Honkbot:
                         <= east_time <= end_time.astimezone(pytz.timezone("America/New_York"))
                 ):
 
-                    self.client.send_message(
+                    await self.client.send_message(
                         message.channel,
                         "Other: :x: - {0}-{1}".format(
                             begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
                             end_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M")))
                 else:
-                    self.client.send_message(
+                    await self.client.send_message(
                         message.channel,
                         "Other: :white_check_mark: - {0}-{1}".format(
                             begin_time.astimezone(pytz.timezone("America/New_York")).strftime("%H:%M"),
@@ -201,7 +201,7 @@ class Honkbot:
         """
         r = requests.get("http://quandyfactory.com/insult/json")
         insult = r.json()["insult"]
-        self.client.send_message(message.channel, insult.replace("Thou art", "{0} is".format(name)))
+        await self.client.send_message(message.channel, insult.replace("Thou art", "{0} is".format(name)))
 
     async def get_record(self, message):
         """
@@ -212,7 +212,7 @@ class Honkbot:
         """
 
         if not self.speedrun_api:
-            self.client.send_message(
+            await self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -261,36 +261,36 @@ class Honkbot:
                             r = requests.get("".join([base_url, "users/", user_id]), headers=auth)
                             user_name = r.json()['data']['names']['international']
 
-                            self.client.send_message(
+                            await self.client.send_message(
                                 message.channel,
                                 "The Any% record for {0} is {1} by {2}".format(game_name, record, user_name))
                 
                         else:
-                            self.client.send_message(
+                            await self.client.send_message(
                                 message.channel,
                                 "There are no Any% records for {}".format(game_name))
                     elif len(results) < 5:
                         names = []
                         for result in results:
                             names.append(result['names']['international'])
-                        self.client.send_message(
+                        await self.client.send_message(
                             message.channel,
                             "Multiple results. Do a search for the following: {}".format(
                                 ", ".join(names)))
-                        self.client.send_message(
+                        await self.client.send_message(
                             message.channel,
                             "If you want the first result, redo the search")
                     else:
-                        self.client.send_message(
+                        await self.client.send_message(
                             message.channel,
                             "Too many results! Be a little more specific")
                 else:
-                    self.client.send_message(
+                    await self.client.send_message(
                         message.channel,
                         "No games with that name found!")
             self.lastRecordSearch = query
         else:
-            self.client.send_message(
+            await self.client.send_message(
                 message.channel,
                 "You gotta give me a game to look for...")
 
@@ -303,7 +303,7 @@ class Honkbot:
         """
 
         if not self.google_api:
-            self.client.send_message(
+            await self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -321,13 +321,13 @@ class Honkbot:
                 r = requests.get(url)
                 try:
                     response = r.json()["items"][0]["link"]
-                    self.client.send_message(message.channel, response)
+                    await self.client.send_message(message.channel, response)
                 except KeyError:
-                    self.client.send_message(message.channel, "No results found for {0} :(".format(query))
+                    await self.client.send_message(message.channel, "No results found for {0} :(".format(query))
             else:
-                self.client.send_message(message.channel, "Query too big!")
+                await self.client.send_message(message.channel, "Query too big!")
         else:
-            self.client.send_message(message.channel, "Usage: !image <search term>")
+            await self.client.send_message(message.channel, "Usage: !image <search term>")
 
     async def search_youtube(self, message):
         """
@@ -338,7 +338,7 @@ class Honkbot:
         """
 
         if not self.google_api:
-            self.client.send_message(
+            await self.client.send_message(
                 message.channel,
                 "Sorry, cant do that right now! Ask your admin to enable"
             )
@@ -355,19 +355,21 @@ class Honkbot:
                 try:
                     response = r.json()['items'][0]["id"]["videoId"]
                 except IndexError:
-                    self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
+                    await self.client.send_message(message.channel, "Could not find any videos with search {0}"
+                                                   .format(query))
                     return
 
                 if response:
-                    self.client.send_message(message.channel, "https://youtu.be/{0}".format(response))
+                    await self.client.send_message(message.channel, "https://youtu.be/{0}".format(response))
                 else:
-                    self.client.send_message(message.channel, "Could not find any videos with search {0}".format(query))
+                    await self.client.send_message(message.channel, "Could not find any videos with search {0}"
+                                                   .format(query))
                     return
             else:
-                self.client.send_message(message.channel, "Query too long!")
+                await self.client.send_message(message.channel, "Query too long!")
                 return
         else:
-            self.client.send_message(message.channel, "Usage: !youtube <search terms>")
+            await self.client.send_message(message.channel, "Usage: !youtube <search terms>")
 
     async def set_channel_role(self, message):
         """
@@ -379,11 +381,11 @@ class Honkbot:
 
         allowed_roles = ['OH', 'MI', 'KY', 'PA', 'IN', 'NY']
         if len(message.content.split(" ")) != 2:
-            self.client.send_message(message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles), "]"]))
+            await self.client.send_message(message.channel, "".join(["Usage: !join [", ", ".join(allowed_roles), "]"]))
             return
         role = message.content.split(" ")[1]
         if role not in allowed_roles:
-            self.client.send_message(message.channel, "".join(["Allowed roles are: ", ", ".join(allowed_roles)]))
+            await self.client.send_message(message.channel, "".join(["Allowed roles are: ", ", ".join(allowed_roles)]))
         else:
             role_object = discord.utils.get(message.server.roles, name=role)
             try:
@@ -391,10 +393,10 @@ class Honkbot:
                     await self.client.replace_roles(message.author, role_object)
                 else:
                     await self.client.add_roles(message.author, role_object) 
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel, "Adding {0} to {1}".format(message.author.name, role))
             except Forbidden:
-                self.client.send_message(
+                await self.client.send_message(
                     message.channel, "I do not have permissions to assign roles right now. Sorry!")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py>=0.16.12
 python-dotenv>=0.9.1
+pytz==2018.5
+requests==2.20.0


### PR DESCRIPTION
### Purpose

This PR aims to clean up PEP8 warnings and other unclear bits of code so that it's easier for multiple maintainers and also so that IDEs don't complain unless there's actually a problem.

### Changes

- Plenty of spacing changes everywhere, particularly before function names and after punctuation
- Removed a few unused imports (we can add them back) and also variables
- Changed `warn` to ~the non-deprecated `warning`~ `info` instead.
- Minor spelling/naming errors throughout
- Added two requirements that are not part of the standard library and also I believe are not included with the other requirements
- Rewrite eAmuse maintenance checks to be more readable (and maintainable)

### Risk Mitigation

Tests performed on a testing server with approximately equal setup to the main Ohio DDR server.

Functionality Tests:
- [x] test
- [x] join
- [x] help
- [x] youtube
- [x] image
- [x] insult
- [x] ranatalus
- [x] record
- [x] eamuse
- [x] honk - can't test Skeeter

### Notes

For some reason, there is still a warning about the usage of `await`. I think this is on the discord.py and not anything we can get around. In my IDE I've chosen to ignore this error for `Message.class` otherwise it fills up everything.