### PR TITLE
Timezone Hotfix

### DIFF
--- a/honkbot.py
+++ b/honkbot.py
@@ -168,9 +168,9 @@ class Honkbot:
         today_in_eastern = datetime.datetime.utcnow().replace(tzinfo=pytz.timezone("America/New_York"))
 
         # If it's Monday in America, and either the third Tuesday or the Monday before that in Japan
-        if today_in_eastern.weekday == 0 and (
-                (today_in_japan.weekday == 1 and 15 <= today_in_japan.day <= 21) or (
-                tomorrow_in_japan.weekday == 1 and 15 <= tomorrow_in_japan.day <= 21)):
+        if today_in_eastern.weekday() == 0 and (
+                (today_in_japan.weekday() == 1 and 15 <= today_in_japan.day <= 21) or (
+                tomorrow_in_japan.weekday() == 1 and 15 <= tomorrow_in_japan.day <= 21)):
             return True
         return False
 


### PR DESCRIPTION
Turns out `.weekday` brings back and actual datetime object... we wanted `.weekday()` to get the integer weekday instead. Eamuse time should be fixed with this small change.

(Notably, `.day` is correct, it is NOT `.day()`)