### PR TITLE
Slightly smarter bot triggering

### DIFF
--- a/honkbot.py
+++ b/honkbot.py
@@ -125,7 +125,7 @@ class Honkbot:
             else:
                 await self.client.send_message(message.channel, "HONK!")
 
-        elif message.content.startswith('!'):
+        elif message.content.startswith('!') and not set(message.content).issubset(set('! ')):
             commands = "".join(["Commands are: ", ", ".join(self.command_list)])
             await self.client.send_message(message.channel, commands)
 


### PR DESCRIPTION
### Purpose

It's been bugging me when people show surprise by saying `!` which triggers the bot to go into a spiel about how to correctly use the bot. It's been on a list of minor things I wanted to tweak so I knocked it out during lunch today.

### Changes

- The bot will no longer trigger on messages that have only exclamation marks and spaces

### Risk Mitigation

All normal commands work on my test server, and the bot no longer triggers on lone exclamation points or several in a row or whatever else.