### PR TITLE
Added rules bot that adds users to roles that accept terms of a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Honkbot takes advantage of the following services:
 
 Calling Honkbot directly, it will try to find the `.env` file located in the same directory. This file contains user specific settings such as API keys for the various services. You can find the template for the `.env` file in `env.example`
 
+## Discord API Settings
+
+Discord introduced the concept of Intent into their APIs which allows bots to monitor certain event buses and load them into caches. In order for the bot to work correctly, you must make sure that the `Server Members Intent` is enabled in your bot settings as it is disabled by default. More information on intents as well as enabling the server members intent can be found [here](https://gist.github.com/advaith1/e69bcc1cdd6d0087322734451f15aa2f#getting-privileged-intents)
+
 ## Contributing
 
 Want to help keep Honkbot awesome? Great! Just a couple things:

--- a/bots/rules.py
+++ b/bots/rules.py
@@ -1,0 +1,22 @@
+import discord
+from discord.ext import commands
+
+class RulesBot(commands.Cog):
+    """
+    Bot that controls whether or not a user has read the server rules via reactions
+    """
+    def __init__(self, bot, rules_channel, rules_message, rules_emoji, rules_role):
+        self.bot = bot
+        self.rules_channel = int(rules_channel)
+        self.rules_message = int(rules_message)
+        self.rules_emoji = rules_emoji
+        self.rules_role = rules_role
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload):
+        if payload.channel_id == self.rules_channel and payload.message_id == self.rules_message:
+            if payload.emoji.name == self.rules_emoji:
+                guild = self.bot.get_guild(payload.guild_id)
+                role = discord.utils.get(guild.roles, name=self.rules_role)
+                user = guild.get_member(payload.user_id)
+                await user.add_roles(role)

--- a/bots/rules.py
+++ b/bots/rules.py
@@ -1,9 +1,23 @@
 import discord
 from discord.ext import commands
 
+
 class RulesBot(commands.Cog):
     """
     Bot that controls whether or not a user has read the server rules via reactions
+
+    :param bot: The bot that is calling this cog
+    :type bot: commands.Bot
+    :param rules_channel: Channel ID of the channel that contains the message to monitor
+    :type rules_channel: str
+    :param rules_message: Message ID of the message to monitor
+    :type rules_message: str
+    :param rules_emoji: Name of the emoji to monitor the message for
+    :type rules_emoji: str
+    :param rules_role: Name of the role to add/remove
+    :type rules_role: str
+
+    :return: None
     """
     def __init__(self, bot, rules_channel, rules_message, rules_emoji, rules_role):
         self.bot = bot
@@ -14,9 +28,44 @@ class RulesBot(commands.Cog):
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
+        """
+        Cog listener that waits for a reaction to be added to a message.
+
+        When the correct reaction is made to the rules message, the user is added to the rules role.
+        Other emojis added to the message are cleared. All other messages are ignored
+
+        :param payload: payload given by discord of reaction event
+        :type payload: discord.RawReactionActionEvent
+
+        :return: None
+        """
         if payload.channel_id == self.rules_channel and payload.message_id == self.rules_message:
+            guild = self.bot.get_guild(payload.guild_id)
+            user = guild.get_member(payload.user_id)
             if payload.emoji.name == self.rules_emoji:
-                guild = self.bot.get_guild(payload.guild_id)
                 role = discord.utils.get(guild.roles, name=self.rules_role)
-                user = guild.get_member(payload.user_id)
                 await user.add_roles(role)
+            else:
+                channel = guild.get_channel(payload.channel_id)
+                message = channel.get_partial_message(payload.message_id)
+                await message.clear_reaction(payload.emoji)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload):
+        """
+        Cog listener that waits for a reaction to be removed from a message.
+
+        When the correct reaction is removed from the rules message, the user has their role removed.
+        All other messages are ignored.
+
+        :param payload: payload given by discord of reaction event
+        :type payload: discord.RawReactionActionEvent
+
+        :return: None
+        """
+        if payload.channel_id == self.rules_channel and payload.message_id == self.rules_message:
+            guild = self.bot.get_guild(payload.guild_id)
+            user = guild.get_member(payload.user_id)
+            if payload.emoji.name == self.rules_emoji:
+                role = discord.utils.get(guild.roles, name=self.rules_role)
+                await user.remove_roles(role)

--- a/env.example
+++ b/env.example
@@ -1,6 +1,19 @@
+# API Keys
 DISCORD_API_KEY=
 SPEEDRUN_API_KEY=
 GOOGLE_API_KEY=
+
+# RulesBot information
+# Channel ID that contains the rules of the server
+RULES_CHANNEL=
+# Message ID of the post that contains the rules of the server
+RULES_MESSAGE=
+# The name of the emoji that users should react with
+RULES_EMOJI=
+# The name of the role that the user will be assigned to
+RULES_ROLE=
+
+# Postgres database information used for the Eamuse rivals bot
 POSTGRES_HOST=
 POSTGRES_PORT=5432
 POSTGRES_USER=honkbot

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-discord.py==1.3.4
+discord.py==1.7.3
 python-dotenv>=0.9.1
 pytz==2018.5
 requests==2.20.0
 beautifulsoup4==4.6.3
-psycopg2==2.8.4
+psycopg2-binary==2.8.4

--- a/startup.py
+++ b/startup.py
@@ -1,9 +1,13 @@
 import logging
 import dotenv
 import os
+
+import discord
+
 from bots.honkbot import Honkbot
 from bots.remy import Remybot
 from bots.codes import EamuseRivals
+from bots.rules import RulesBot
 from discord.ext.commands import Bot
 import sys
 
@@ -14,15 +18,30 @@ if "__main__" in __name__:
     logger.info("Starting Honkbot...")
 
     dotenv.load_dotenv()
+    # API keys
     discord_api_key = os.getenv("DISCORD_API_KEY")
     speedrun_api_key = os.getenv("SPEEDRUN_API_KEY")
     google_api_key = os.getenv("GOOGLE_API_KEY")
+    # Arguments for the rules bot
+    rules_channel = os.getenv("RULES_CHANNEL")
+    rules_message = os.getenv("RULES_MESSAGE")
+    rules_emoji = os.getenv("RULES_EMOJI")
+    rules_role = os.getenv("RULES_ROLE")
 
-    bot = Bot(command_prefix='!')
+    intents = discord.Intents(messages=True, reactions=True, guilds=True, members=True)
+
+    bot = Bot(command_prefix='!', intents=intents)
 
     honkbot = Honkbot(logger, speedrun_api_key, google_api_key, bot=bot)
     bot.add_cog(honkbot)
     bot.add_cog(Remybot())
     bot.add_cog(EamuseRivals())
+    if rules_channel and rules_message and rules_emoji and rules_role:
+        bot.add_cog(RulesBot(bot, rules_channel, rules_message, rules_emoji, rules_role))
+    else:
+        logger.warning(
+            "Not all RULE environment variables set. Check .env for missing assignments"
+        )
+        logger.warning("RulesBot disabled")
 
     bot.run(discord_api_key)


### PR DESCRIPTION
## Other changes
- Updated discord.py to latest version.
- Updated README with new info about intents
- Added comments into `env.example`

## Purpose
This PR will introduce the Rules Bot, a cog that takes a message id, channel id, emoji name, and role name and listens for any reaction adds. Once a user reacts to a certain message with a certain emoji, a role will be granted to that user. This will allow a server to enforce a terms of service, forcing users to accept any rules of the server. This way, users cannot say that they didn't see the rules. The server can then be locked down so that users can only view the rest of the channels on a server if they are added to the given role.

## Example
1. User joins server
2. With no roles, user can only view one channel the contains the rules
3. User reads rules explaining how to unlock the rest of the channel with a react
4. User reacts to message with accepted emoji
5. User is added to role that unlocks all other channels
6. If user removes react, role is removed from the user

## To do after deployment
- Implement roles on our main server
- Create channel and message with rules
- Update k8s secrets with rules variables and redeploy

## Tests done
- Add react to unrelated message. No action taken
- Add react to rules message with unspecified emoji. Reaction removed
- Add react to rules message with specified emoji. Role added to user
- Remove react from rules message. Role removed from user